### PR TITLE
Disabling removal of libunwind in pre

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -74,7 +74,7 @@ prepare() {
     
     cd llvm-project
     # llvm-project contains a lot of stuff, remove parts that aren't used by this package
-    rm -rf debuginfo-tests libclc libcxx libcxxabi libunwind llgo openmp parallel-libs pstl libc
+    rm -rf debuginfo-tests libclc libcxx libcxxabi llgo openmp parallel-libs pstl libc
     
     cd clang
 }


### PR DESCRIPTION
Build error due to a missing dependency of libunwind file, keeping the libunwind in the build fixed the issue.

I don't want to rerun the script with it but if you need the exact error message let me know.